### PR TITLE
Document original paper on pratt parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,3 +60,10 @@ Major parts of the interpreter:
 - abstract syntax tree (AST)
 - internal object system
 - evaluator
+
+## Top Down Operator Precedence
+
+<!--TODO: Document how Pratt parsing works-->
+
+- Pratt, Vaughan - [Top Down Operator Precedence](https://github.com/tdop/tdop.github.io/tree/master)
+- Kladow, Alex - [Simple but Powerful Pratt Parsing](https://matklad.github.io/2020/04/13/simple-but-powerful-pratt-parsing.html)


### PR DESCRIPTION
Adds link to the original paper and  to a really good article (which in return links to this [survey post](https://www.oilshell.org/blog/2017/03/31.html)).

Also adds a little reminder to add some proper documentation on how pratt / top-down-operator-precedence parsing works.